### PR TITLE
update Israel TLD

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -1113,8 +1113,9 @@ web.id
 ie
 gov.ie
 
-// il : http://en.wikipedia.org/wiki/.il
-*.il
+// il : http://www.isoc.org.il/domains/
+co.il
+org.il
 
 // im : https://www.nic.im/
 // Submitted by registry <info@nic.im> 2013-11-15


### PR DESCRIPTION
The IANA lists isoc.org.il as the group delegated to managing the .il TLD.
http://www.iana.org/domains/root/db/il.html

isoc.org.il states that co.il and org.il are the only two domains available from accredited registrars.
http://www.isoc.org.il/domains/
